### PR TITLE
Upgraded stimulus

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "stimulus": "~2.0"
+    "stimulus": "~3.0"
   },
   "bugs": {
     "url": "https://gitlab.com/initforthe/stimulus-reveal/issues"


### PR DESCRIPTION
I'm not sure how you want to do this, but the click-jack bug will reappear for Stimulus 3.0 unless you update this dependency to match the version of Stimulus being used by the user using stimulus-reveal.

Prior to updating this, I would warn the user that if they are using Stimulus 2.0 and upgrade to Stimulus 3.0, this dependency failing will result in the library not working.